### PR TITLE
feat: gasbot disable chain switching

### DIFF
--- a/packages/ui/app/_components/Navbar.tsx
+++ b/packages/ui/app/_components/Navbar.tsx
@@ -92,9 +92,9 @@ export default function Navbar() {
             </p>
           </Link>
           <Gasbot.CustomRender
+            avoidChainSwitching={true}
             limitDestination={34443}
             walletClientOrSigner={signer}
-            avoidChainSwitching={true}
           >
             {({ openGasbotModal }) => (
               <Link

--- a/packages/ui/app/_components/Navbar.tsx
+++ b/packages/ui/app/_components/Navbar.tsx
@@ -1,20 +1,20 @@
 /* eslint-disable @next/next/no-img-element */
 'use client';
-// import { Gasbot } from '@gasbot/widget';
+import { Gasbot } from '@gasbot/widget';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import React, { useState } from 'react';
-// import '@gasbot/widget/style.css';
+import '@gasbot/widget/style.css';
 
 import ConnectButton from './ConnectButton';
 
-// import { useEthersSigner } from '@ui/hooks/useEthersSigner';
+import { useEthersSigner } from '@ui/hooks/useEthersSigner';
 // import { useStore } from "@/store/Store";
 
 export default function Navbar() {
   const [isActive, setIsActive] = useState<boolean>(false);
   const pathname = usePathname();
-  // const signer = useEthersSigner();
+  const signer = useEthersSigner();
 
   // useEffect(()=>{
   //   console.log(pathbox.current.getElementsByClassName(pathname));
@@ -91,9 +91,10 @@ export default function Navbar() {
               Dashboard
             </p>
           </Link>
-          {/* <Gasbot.CustomRender
+          <Gasbot.CustomRender
             limitDestination={34443}
             walletClientOrSigner={signer}
+            avoidChainSwitching={true}
           >
             {({ openGasbotModal }) => (
               <Link
@@ -108,7 +109,7 @@ export default function Navbar() {
                 </p>
               </Link>
             )}
-          </Gasbot.CustomRender> */}
+          </Gasbot.CustomRender>
           {/* <Link href={`/market`}>
             <p
               className={`${

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@gasbot/widget": "^0.3.11",
+    "@gasbot/widget": "^0.3.19",
     "@sentry/nextjs": "^7.48.0",
     "@supabase/supabase-js": "^2.39.7",
     "@tanstack/react-query": "4.29.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,9 +1963,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gasbot/widget@npm:^0.3.11":
-  version: 0.3.11
-  resolution: "@gasbot/widget@npm:0.3.11"
+"@gasbot/widget@npm:^0.3.19":
+  version: 0.3.19
+  resolution: "@gasbot/widget@npm:0.3.19"
   dependencies:
     "@radix-ui/react-dialog": "npm:^1.0.5"
     "@radix-ui/react-popover": "npm:^1.0.7"
@@ -1986,7 +1986,7 @@ __metadata:
     ethers: ^5.0.0 || ^6.0.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10/b2d9f1b72b7222c9f1bcba4c696e0cae9ebe79973bc6691d0b577bbdd63b945c0e0cb14688b55b1aecadc9e4bb7838fd3108e9d1914930524ff783eaef79ebf9
+  checksum: 10/503aed29e93a26374cb2e864044074db30c5e0acd3582a5732e9849adf82e60e2ddfe0b24f27b38c5dc8b39b67552510626015c5573e8e39acf2159c283607c3
   languageName: node
   linkType: hard
 
@@ -2367,7 +2367,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ionicprotocol/ui@workspace:packages/ui"
   dependencies:
-    "@gasbot/widget": "npm:^0.3.11"
+    "@gasbot/widget": "npm:^0.3.19"
     "@sentry/nextjs": "npm:^7.48.0"
     "@supabase/supabase-js": "npm:^2.39.7"
     "@tanstack/react-query": "npm:4.29.3"


### PR DESCRIPTION
## Description

Update @gasbot/widget to version 0.3.19. Add `avoidChainSwitching` prop to ensure that users cannot switch chains away from Mode. This allows users to sign permit messages on any stablecoins held on other Gasbot-supported chains to receive Mode ETH.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

The user will be able to click the "Get Gas" button in the navbar which opens the Gasbot modal. The modal scans the connected wallet for stablecoins across various networks that can be used to obtain Mode ETH.

## Related Issue(s)

None

## Related pull request(s)

https://github.com/ionicprotocol/monorepo/pull/212
