### PR TITLE
Hide + OP rewards from mode native pool

### DIFF
--- a/packages/ui/app/_components/markets/Rewards.tsx
+++ b/packages/ui/app/_components/markets/Rewards.tsx
@@ -98,42 +98,44 @@ const Rewards = ({
           %
         </div>
       ))}
-      <div className="py-4">
-        {combinedRewards.map((rewards, index) => (
-          <div
-            className={`flex ${className ?? 'none'}`}
-            key={index}
-          >
-            <img
-              alt=""
-              className="size-4 rounded mr-1"
-              src={`/img/symbols/32/color/${REWARDS_TO_SYMBOL[poolChainId]?.[rewards?.rewardToken]?.toLowerCase()}.png`}
-            />{' '}
-            +{' '}
-            {Number(formatEther(rewards.amount)).toLocaleString('en-US', {
-              maximumFractionDigits: 1
-            })}{' '}
-            {REWARDS_TO_SYMBOL[poolChainId][rewards.rewardToken]}
-          </div>
-        ))}
-        {totalRewards > 0n && (
-          <div className="flex justify-center pt-1">
-            <button
-              className={`rounded-md bg-accent text-black py-1 px-3 uppercase truncate `}
-              onClick={claimRewards}
+      {(totalRewards > 0 || combinedRewards.length > 0) && (
+        <div className="py-4">
+          {combinedRewards.map((rewards, index) => (
+            <div
+              className={`flex ${className ?? 'none'}`}
+              key={index}
             >
-              <ResultHandler
-                isLoading={isLoading}
-                height="20"
-                width="20"
-                color={'#000000'}
+              <img
+                alt=""
+                className="size-4 rounded mr-1"
+                src={`/img/symbols/32/color/${REWARDS_TO_SYMBOL[poolChainId]?.[rewards?.rewardToken]?.toLowerCase()}.png`}
+              />{' '}
+              +{' '}
+              {Number(formatEther(rewards.amount)).toLocaleString('en-US', {
+                maximumFractionDigits: 1
+              })}{' '}
+              {REWARDS_TO_SYMBOL[poolChainId][rewards.rewardToken]}
+            </div>
+          ))}
+          {totalRewards > 0n && (
+            <div className="flex justify-center pt-1">
+              <button
+                className={`rounded-md bg-accent text-black py-1 px-3 uppercase truncate `}
+                onClick={claimRewards}
               >
-                Claim Rewards
-              </ResultHandler>
-            </button>
-          </div>
-        )}
-      </div>
+                <ResultHandler
+                  isLoading={isLoading}
+                  height="20"
+                  width="20"
+                  color={'#000000'}
+                >
+                  Claim Rewards
+                </ResultHandler>
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/packages/ui/app/_components/markets/SupplyPopover.tsx
+++ b/packages/ui/app/_components/markets/SupplyPopover.tsx
@@ -101,7 +101,7 @@ export default function SupplyPopover({
             %
           </span>
         </div>
-        {isModeMarket && (
+        {isModeMarket && selectedPoolId !== '1' && (
           <div className="flex items-center mt-1">
             <img
               src="/images/op-logo-red.svg"


### PR DESCRIPTION
also fixed a visual bug that was displaying an empty div even when there were no rewards. 

before/after:
![Screenshot 2024-10-23 at 13 55 45](https://github.com/user-attachments/assets/a41ed13a-07c3-4e7f-bedb-2435c09e2b42)
![Screenshot 2024-10-23 at 13 55 51](https://github.com/user-attachments/assets/65772e6e-00a8-49bf-b152-fcb344bb7a3f)
