### PR TITLE
Remove turtle and mode from mode and main

### DIFF
--- a/packages/ui/app/_components/dashboards/InfoRows.tsx
+++ b/packages/ui/app/_components/dashboards/InfoRows.tsx
@@ -12,7 +12,7 @@ import { multipliers } from '@ui/utils/multipliers';
 import { handleSwitchOriginChain } from '@ui/utils/NetworkChecker';
 
 import { getAssetName } from '../../util/utils';
-const Rewards = dynamic(() => import('../markets/Rewards'), {
+const Rewards = dynamic(() => import('../markets/FlyWheelRewards'), {
   ssr: false
 });
 import BorrowPopover from '../markets/BorrowPopover';

--- a/packages/ui/app/_components/markets/BorrowPopover.tsx
+++ b/packages/ui/app/_components/markets/BorrowPopover.tsx
@@ -2,13 +2,14 @@
 import dynamic from 'next/dynamic';
 
 import { pools } from '@ui/constants/index';
-import { hasAdditionalRewards, multipliers } from '@ui/utils/multipliers';
+import { useRewardsBadge } from '@ui/hooks/useRewardsBadge';
+import { multipliers } from '@ui/utils/multipliers';
 
 import type { Address } from 'viem';
 
 import type { FlywheelReward } from '@ionicprotocol/types';
 
-const Rewards = dynamic(() => import('./Rewards'), {
+const Rewards = dynamic(() => import('./FlyWheelRewards'), {
   ssr: false
 });
 
@@ -37,11 +38,12 @@ export default function BorrowPopover({
   const borrowConfig =
     multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.borrow;
 
-  const showRewardsBadge = hasAdditionalRewards(
+  const showRewardsBadge = useRewardsBadge(
     dropdownSelectedChain,
     selectedPoolId,
     asset,
-    'borrow'
+    'borrow',
+    rewards
   );
 
   return (
@@ -176,14 +178,6 @@ export default function BorrowPopover({
                     ]?.borrow?.etherfi
                   }
                   x ether.fi Points
-                </div>
-                <div className="flex">
-                  <img
-                    alt=""
-                    className="size-4 mr-1"
-                    src="/images/turtle-etherfi.png"
-                  />{' '}
-                  + Turtle ether.fi Points
                 </div>
               </>
             )}

--- a/packages/ui/app/_components/markets/BorrowPopover.tsx
+++ b/packages/ui/app/_components/markets/BorrowPopover.tsx
@@ -131,38 +131,18 @@ export default function BorrowPopover({
                 </div>
               </>
             )}
-
-            {Boolean(
-              multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-                ?.borrow?.mode
-            ) &&
-              asset !== 'USDC' &&
-              asset !== 'WETH' && (
-                <>
-                  <div className="flex">
-                    <img
-                      alt=""
-                      className="size-4 mr-1"
-                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzM4OTZfMzU4MDcpIj4KPHBhdGggZD0iTTEyLjIzNTYgMC44MDAwNDlIMy43NjQ0NkwwLjgwMDA0OSAzLjc2NDQ1VjEyLjIzNTZMMy43NjQ0NiAxNS4ySDEyLjIzNTZMMTUuMiAxMi4yMzU2VjMuNzY0NDVMMTIuMjM1NiAwLjgwMDA0OVpNMTIuMzM3NyAxMS44Mzc0SDEwLjY0NjJWOC4wMTE5NkwxMS4zMjM1IDUuODMwMzVMMTAuODQzNiA1LjY2MDE4TDguNjQ4NDEgMTEuODM3NEg3LjM2MTkxTDUuMTY2NjggNS42NjAxOEw0LjY4Njc5IDUuODMwMzVMNS4zNjQwOCA4LjAxMTk2VjExLjgzNzRIMy42NzI1N1Y0LjE2MjY2SDYuMTkxMTJMNy43NTMzIDguNTU2NTFWOS44NDY0Mkg4LjI2MzgyVjguNTU2NTFMOS44MjYgNC4xNjI2NkgxMi4zNDQ1VjExLjgzNzRIMTIuMzM3N1oiIGZpbGw9IiNERkZFMDAiLz4KPC9nPgo8ZGVmcz4KPGNsaXBQYXRoIGlkPSJjbGlwMF8zODk2XzM1ODA3Ij4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSJ3aGl0ZSIvPgo8L2NsaXBQYXRoPgo8L2RlZnM+Cjwvc3ZnPgo="
-                    />{' '}
-                    +{' '}
-                    {
-                      multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[
-                        asset
-                      ]?.borrow?.mode
-                    }
-                    x Mode Points
-                  </div>
-                  <div className="flex">
-                    <img
-                      alt=""
-                      className="size-4 mr-1"
-                      src="/images/turtle-mode.png"
-                    />{' '}
-                    + Turtle Mode Points
-                  </div>
-                </>
-              )}
+            {borrowConfig?.turtle && asset === 'STONE' && (
+              <>
+                <div className="flex">
+                  <img
+                    alt=""
+                    className="size-4 mr-1"
+                    src="/img/symbols/32/color/stone.png"
+                  />{' '}
+                  + Stone Turtle Points
+                </div>
+              </>
+            )}
             {borrowConfig?.etherfi && (
               <>
                 <div className="flex">

--- a/packages/ui/app/_components/markets/BorrowPopover.tsx
+++ b/packages/ui/app/_components/markets/BorrowPopover.tsx
@@ -128,8 +128,10 @@ export default function BorrowPopover({
               </>
             )}
 
-            {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-              ?.borrow?.mode &&
+            {Boolean(
+              multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
+                ?.borrow?.mode
+            ) &&
               asset !== 'USDC' &&
               asset !== 'WETH' && (
                 <>

--- a/packages/ui/app/_components/markets/BorrowPopover.tsx
+++ b/packages/ui/app/_components/markets/BorrowPopover.tsx
@@ -2,7 +2,7 @@
 import dynamic from 'next/dynamic';
 
 import { pools } from '@ui/constants/index';
-import { multipliers } from '@ui/utils/multipliers';
+import { hasAdditionalRewards, multipliers } from '@ui/utils/multipliers';
 
 import type { Address } from 'viem';
 
@@ -34,12 +34,21 @@ export default function BorrowPopover({
   const isModeMarket =
     dropdownSelectedChain === 34443 && (asset === 'USDC' || asset === 'WETH');
 
+  const borrowConfig =
+    multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.borrow;
+
+  const showRewardsBadge = hasAdditionalRewards(
+    dropdownSelectedChain,
+    selectedPoolId,
+    asset,
+    'borrow'
+  );
+
   return (
     <>
       <span
         className={`rounded-md w-max md:text-[10px] text-[8px] md:mb-1 ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-3.5 px-1 ${
-          multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.borrow
-            ?.ionAPR
+          borrowConfig?.ionAPR
             ? 'bg-accent text-green-900 '
             : 'bg-accent/50 text-green-900 '
         }`}
@@ -47,35 +56,31 @@ export default function BorrowPopover({
         + ION APR <i className="popover-hint">i</i>
       </span>
 
-      {multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.borrow
-        ?.rewards &&
-        !isModeMarket && (
-          <span
-            className={`${pools[+dropdownSelectedChain].text} ${pools[+dropdownSelectedChain].bg} rounded-md w-max lg:text-[10px] md:text-[9px] text-[8px] md:mb-1 py-[1px] md:px-1 lg:px-2.5 px-1 ml-1 md:ml-0 text-center`}
-          >
-            + REWARDS <i className="popover-hint">i</i>
-          </span>
-        )}
+      {showRewardsBadge && !isModeMarket && (
+        <span
+          className={`${pools[+dropdownSelectedChain].text} ${pools[+dropdownSelectedChain].bg} rounded-md w-max lg:text-[10px] md:text-[9px] text-[8px] md:mb-1 py-[1px] md:px-1 lg:px-2.5 px-1 ml-1 md:ml-0 text-center`}
+        >
+          + REWARDS <i className="popover-hint">i</i>
+        </span>
+      )}
 
-      {multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.borrow
-        ?.turtle &&
-        !isModeMarket && (
-          <span className="text-darkone rounded-md w-max md:ml-0 text-center ">
-            <a
-              className="text-darkone bg-white rounded-md w-max ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-3.5 px-1 flex items-center justify-center gap-1 md:text-[10px] text-[8px]"
-              href="https://turtle.club/dashboard/?ref=IONIC"
-              target="_blank"
-              rel="noreferrer"
-            >
-              + TURTLE{' '}
-              <img
-                alt="external-link"
-                className="w-3 h-3"
-                src="https://img.icons8.com/material-outlined/24/external-link.png"
-              />
-            </a>
-          </span>
-        )}
+      {borrowConfig?.turtle && !isModeMarket && (
+        <span className="text-darkone rounded-md w-max md:ml-0 text-center ">
+          <a
+            className="text-darkone bg-white rounded-md w-max ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-3.5 px-1 flex items-center justify-center gap-1 md:text-[10px] text-[8px]"
+            href="https://turtle.club/dashboard/?ref=IONIC"
+            target="_blank"
+            rel="noreferrer"
+          >
+            + TURTLE{' '}
+            <img
+              alt="external-link"
+              className="w-3 h-3"
+              src="https://img.icons8.com/material-outlined/24/external-link.png"
+            />
+          </a>
+        </span>
+      )}
       <div
         className={`popover absolute min-w-[190px] top-full p-2 px-2 mt-1 border ${pools[dropdownSelectedChain].border} rounded-md text-xs z-30 opacity-0 invisible bg-grayUnselect transition-all`}
       >
@@ -87,11 +92,9 @@ export default function BorrowPopover({
             : '-'}
           %
         </div>
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-          ?.borrow && (
+        {borrowConfig && (
           <>
-            {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-              ?.borrow?.flywheel && (
+            {borrowConfig?.flywheel && (
               <Rewards
                 cToken={cToken}
                 pool={pool}
@@ -100,8 +103,7 @@ export default function BorrowPopover({
                 rewards={rewards}
               />
             )}
-            {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-              ?.borrow?.ionic > 0 && (
+            {borrowConfig?.ionic > 0 && (
               <>
                 <div className="flex ">
                   <img
@@ -159,8 +161,7 @@ export default function BorrowPopover({
                   </div>
                 </>
               )}
-            {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-              ?.borrow?.etherfi && (
+            {borrowConfig?.etherfi && (
               <>
                 <div className="flex">
                   <img
@@ -186,8 +187,7 @@ export default function BorrowPopover({
                 </div>
               </>
             )}
-            {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-              ?.borrow?.kelp && (
+            {borrowConfig?.kelp && (
               <>
                 <div className="flex">
                   <img
@@ -213,8 +213,7 @@ export default function BorrowPopover({
                 </div>
               </>
             )}
-            {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-              ?.borrow?.eigenlayer && (
+            {borrowConfig?.eigenlayer && (
               <div className="flex">
                 <img
                   alt=""
@@ -224,8 +223,7 @@ export default function BorrowPopover({
                 + EigenLayer Points
               </div>
             )}
-            {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-              ?.borrow?.spice && (
+            {borrowConfig?.spice && (
               <div className="flex">
                 <img
                   alt=""

--- a/packages/ui/app/_components/markets/SupplyPopover.tsx
+++ b/packages/ui/app/_components/markets/SupplyPopover.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 import { pools } from '@ui/constants/index';
 import { useMerklApr } from '@ui/hooks/useMerklApr';
-import { multipliers } from '@ui/utils/multipliers';
+import { hasAdditionalRewards, multipliers } from '@ui/utils/multipliers';
 
 import type { Address } from 'viem';
 
@@ -43,6 +43,16 @@ export default function SupplyPopover({
     (a) => Object.keys(a)[0].toLowerCase() === cToken.toLowerCase()
   )?.[cToken];
 
+  const supplyConfig =
+    multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply;
+
+  const showRewardsBadge = hasAdditionalRewards(
+    dropdownSelectedChain,
+    selectedPoolId,
+    asset,
+    'supply'
+  );
+
   return (
     <>
       <span
@@ -56,9 +66,8 @@ export default function SupplyPopover({
         + ION APR <i className="popover-hint">i</i>
       </span>
 
-      {(multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-        ?.rewards ||
-        isMainModeMarket) && (
+      {/* Rewards Badge */}
+      {showRewardsBadge && (
         <span
           className={`${pools[+dropdownSelectedChain].text} ${pools[+dropdownSelectedChain].bg} rounded-md w-max lg:text-[10px] md:text-[9px] text-[8px] md:mb-1 ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-2.5 px-1 flex items-center justify-center`}
         >
@@ -79,25 +88,23 @@ export default function SupplyPopover({
         </span>
       )}
 
-      {multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-        ?.turtle &&
-        !isMainModeMarket && (
-          <span className="text-darkone rounded-md w-max md:ml-0 text-center">
-            <a
-              className="text-darkone bg-white rounded-md w-max ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-3.5 px-1 flex items-center justify-center gap-1 md:text-[10px] text-[8px]"
-              href="https://turtle.club/dashboard/?ref=IONIC"
-              target="_blank"
-              rel="noreferrer"
-            >
-              + TURTLE{' '}
-              <img
-                alt="external-link"
-                className="w-3 h-3"
-                src="https://img.icons8.com/material-outlined/24/external-link.png"
-              />
-            </a>
-          </span>
-        )}
+      {supplyConfig?.turtle && !isMainModeMarket && (
+        <span className="text-darkone rounded-md w-max md:ml-0 text-center">
+          <a
+            className="text-darkone bg-white rounded-md w-max ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-3.5 px-1 flex items-center justify-center gap-1 md:text-[10px] text-[8px]"
+            href="https://turtle.club/dashboard/?ref=IONIC"
+            target="_blank"
+            rel="noreferrer"
+          >
+            + TURTLE{' '}
+            <img
+              alt="external-link"
+              className="w-3 h-3"
+              src="https://img.icons8.com/material-outlined/24/external-link.png"
+            />
+          </a>
+        </span>
+      )}
       <div
         className={`popover absolute min-w-[190px] top-full p-2 px-2 mt-1 border ${pools[dropdownSelectedChain].border} rounded-md text-xs z-30 opacity-0 invisible bg-grayUnselect transition-all whitespace-nowrap`}
       >
@@ -131,16 +138,14 @@ export default function SupplyPopover({
           </div>
         )}
         <p>
-          {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-            ?.underlyingAPR &&
+          {supplyConfig?.underlyingAPR &&
             `Native Asset Yield: +${multipliers[dropdownSelectedChain]?.[
               selectedPoolId
             ]?.[asset]?.supply?.underlyingAPR?.toLocaleString('en-US', {
               maximumFractionDigits: 2
             })}%`}
         </p>
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.flywheel && (
+        {supplyConfig?.flywheel && (
           <Rewards
             cToken={cToken}
             pool={pool}
@@ -149,8 +154,7 @@ export default function SupplyPopover({
             rewards={rewards}
           />
         )}
-        {(multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.ionic ?? 0) > 0 && (
+        {(supplyConfig?.ionic ?? 0) > 0 && (
           <>
             <div className="flex mt-1">
               <img
@@ -175,10 +179,7 @@ export default function SupplyPopover({
             </div>
           </>
         )}
-        {Boolean(
-          multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-            ?.mode
-        ) &&
+        {Boolean(supplyConfig?.mode) &&
           asset !== 'USDC' &&
           asset !== 'WETH' && (
             <>
@@ -210,8 +211,7 @@ export default function SupplyPopover({
               </div>
             </>
           )}
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.etherfi && (
+        {supplyConfig?.etherfi && (
           <>
             <div className="flex">
               <img
@@ -236,8 +236,7 @@ export default function SupplyPopover({
             </div>
           </>
         )}
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.renzo && (
+        {supplyConfig?.renzo && (
           <>
             <div className="flex">
               <img
@@ -262,8 +261,7 @@ export default function SupplyPopover({
             </div>
           </>
         )}
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.kelp && (
+        {supplyConfig?.kelp && (
           <>
             <div className="flex">
               <img
@@ -288,8 +286,7 @@ export default function SupplyPopover({
             </div>
           </>
         )}
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.eigenlayer && (
+        {supplyConfig?.eigenlayer && (
           <div className="flex">
             <img
               alt=""
@@ -299,8 +296,7 @@ export default function SupplyPopover({
             + EigenLayer Points
           </div>
         )}
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.spice && (
+        {supplyConfig?.spice && (
           <div className="flex">
             <img
               alt=""
@@ -310,8 +306,7 @@ export default function SupplyPopover({
             + Spice Points
           </div>
         )}
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.nektar && (
+        {supplyConfig?.nektar && (
           <div className="flex mt-1">
             <img
               alt=""

--- a/packages/ui/app/_components/markets/SupplyPopover.tsx
+++ b/packages/ui/app/_components/markets/SupplyPopover.tsx
@@ -32,8 +32,10 @@ export default function SupplyPopover({
   supplyAPR,
   rewards
 }: SupplyPopoverProps) {
-  const isModeMarket =
-    dropdownSelectedChain === 34443 && (asset === 'USDC' || asset === 'WETH');
+  const isMainModeMarket =
+    dropdownSelectedChain === 34443 &&
+    (asset === 'USDC' || asset === 'WETH') &&
+    selectedPoolId === '0';
 
   const { data: merklApr } = useMerklApr();
 
@@ -56,11 +58,11 @@ export default function SupplyPopover({
 
       {(multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
         ?.rewards ||
-        isModeMarket) && (
+        isMainModeMarket) && (
         <span
           className={`${pools[+dropdownSelectedChain].text} ${pools[+dropdownSelectedChain].bg} rounded-md w-max lg:text-[10px] md:text-[9px] text-[8px] md:mb-1 ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-2.5 px-1 flex items-center justify-center`}
         >
-          {isModeMarket ? (
+          {isMainModeMarket ? (
             <>
               +{' '}
               <img
@@ -79,7 +81,7 @@ export default function SupplyPopover({
 
       {multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
         ?.turtle &&
-        !isModeMarket && (
+        !isMainModeMarket && (
           <span className="text-darkone rounded-md w-max md:ml-0 text-center">
             <a
               className="text-darkone bg-white rounded-md w-max ml-1 md:ml-0 text-center py-[1px] md:px-1 lg:px-3.5 px-1 flex items-center justify-center gap-1 md:text-[10px] text-[8px]"
@@ -108,7 +110,7 @@ export default function SupplyPopover({
             %
           </span>
         </div>
-        {isModeMarket && selectedPoolId !== '1' && (
+        {isMainModeMarket && (
           <div className="flex items-center mt-1">
             <img
               src="/images/op-logo-red.svg"
@@ -173,8 +175,10 @@ export default function SupplyPopover({
             </div>
           </>
         )}
-        {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
-          ?.mode &&
+        {Boolean(
+          multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply
+            ?.mode
+        ) &&
           asset !== 'USDC' &&
           asset !== 'WETH' && (
             <>

--- a/packages/ui/app/_components/markets/SupplyPopover.tsx
+++ b/packages/ui/app/_components/markets/SupplyPopover.tsx
@@ -3,13 +3,14 @@ import Link from 'next/link';
 
 import { pools } from '@ui/constants/index';
 import { useMerklApr } from '@ui/hooks/useMerklApr';
-import { hasAdditionalRewards, multipliers } from '@ui/utils/multipliers';
+import { useRewardsBadge } from '@ui/hooks/useRewardsBadge';
+import { multipliers } from '@ui/utils/multipliers';
 
 import type { Address } from 'viem';
 
 import type { FlywheelReward } from '@ionicprotocol/types';
 
-const Rewards = dynamic(() => import('./Rewards'), {
+const Rewards = dynamic(() => import('./FlyWheelRewards'), {
   ssr: false
 });
 
@@ -46,11 +47,12 @@ export default function SupplyPopover({
   const supplyConfig =
     multipliers[+dropdownSelectedChain]?.[selectedPoolId]?.[asset]?.supply;
 
-  const showRewardsBadge = hasAdditionalRewards(
+  const showRewardsBadge = useRewardsBadge(
     dropdownSelectedChain,
     selectedPoolId,
     asset,
-    'supply'
+    'supply',
+    rewards
   );
 
   return (
@@ -225,14 +227,6 @@ export default function SupplyPopover({
                   ?.supply?.etherfi
               }
               x ether.fi Points
-            </div>
-            <div className="flex">
-              <img
-                alt=""
-                className="size-4 mr-1"
-                src="/images/turtle-etherfi.png"
-              />{' '}
-              + Turtle ether.fi Points
             </div>
           </>
         )}

--- a/packages/ui/app/_components/markets/SupplyPopover.tsx
+++ b/packages/ui/app/_components/markets/SupplyPopover.tsx
@@ -181,6 +181,21 @@ export default function SupplyPopover({
             </div>
           </>
         )}
+        {(supplyConfig?.anzen ?? 0) > 0 && (
+          <div className="flex mt-1">
+            <img
+              alt=""
+              className="size-4 rounded mr-1"
+              src="/img/symbols/32/color/usdz.png"
+            />{' '}
+            +{' '}
+            {
+              multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
+                ?.supply?.anzen
+            }
+            x Anzen Points
+          </div>
+        )}
         {Boolean(supplyConfig?.mode) &&
           asset !== 'USDC' &&
           asset !== 'WETH' && (

--- a/packages/ui/app/_components/markets/SupplyPopover.tsx
+++ b/packages/ui/app/_components/markets/SupplyPopover.tsx
@@ -196,38 +196,18 @@ export default function SupplyPopover({
             x Anzen Points
           </div>
         )}
-        {Boolean(supplyConfig?.mode) &&
-          asset !== 'USDC' &&
-          asset !== 'WETH' && (
-            <>
-              <div className="flex">
-                <img
-                  alt=""
-                  className="size-4 mr-1"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzM4OTZfMzU4MDcpIj4KPHBhdGggZD0iTTEyLjIzNTYgMC44MDAwNDlIMy43NjQ0NkwwLjgwMDA0OSAzLjc2NDQ1VjEyLjIzNTZMMy43NjQ0NiAxNS4ySDEyLjIzNTZMMTUuMiAxMi4yMzU2VjMuNzY0NDVMMTIuMjM1NiAwLjgwMDA0OVpNMTIuMzM3NyAxMS44Mzc0SDEwLjY0NjJWOC4wMTE5NkwxMS4zMjM1IDUuODMwMzVMMTAuODQzNiA1LjY2MDE4TDguNjQ4NDEgMTEuODM3NEg3LjM2MTkxTDUuMTY2NjggNS42NjAxOEw0LjY4Njc5IDUuODMwMzVMNS4zNjQwOCA4LjAxMTk2VjExLjgzNzRIMy42NzI1N1Y0LjE2MjY2SDYuMTkxMTJMNy43NTMzIDguNTU2NTFWOS44NDY0Mkg4LjI2MzgyVjguNTU2NTFMOS44MjYgNC4xNjI2NkgxMi4zNDQ1VjExLjgzNzRIMTIuMzM3N1oiIGZpbGw9IiNERkZFMDAiLz4KPC9nPgo8ZGVmcz4KPGNsaXBQYXRoIGlkPSJjbGlwMF8zODk2XzM1ODA3Ij4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSJ3aGl0ZSIvPgo8L2NsaXBQYXRoPgo8L2RlZnM+Cjwvc3ZnPgo="
-                />{' '}
-                +{' '}
-                {
-                  multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-                    ?.supply?.mode
-                }
-                x Mode Points
-              </div>
-              <div className="flex">
-                {multipliers[dropdownSelectedChain]?.[selectedPoolId]?.[asset]
-                  ?.supply?.mode && (
-                  <>
-                    <img
-                      alt=""
-                      className="size-4 mr-1"
-                      src="/images/turtle-mode.png"
-                    />{' '}
-                    + Turtle Mode Points
-                  </>
-                )}
-              </div>
-            </>
-          )}
+        {supplyConfig?.turtle && asset === 'STONE' && (
+          <>
+            <div className="flex">
+              <img
+                alt=""
+                className="size-4 mr-1"
+                src="/img/symbols/32/color/stone.png"
+              />{' '}
+              + Stone Turtle Points
+            </div>
+          </>
+        )}
         {supplyConfig?.etherfi && (
           <>
             <div className="flex">

--- a/packages/ui/hooks/useFlyWheelRewards.ts
+++ b/packages/ui/hooks/useFlyWheelRewards.ts
@@ -1,0 +1,62 @@
+// useFlywheelRewards.ts
+import { useMemo } from 'react';
+
+import { type Address } from 'viem';
+
+import { FLYWHEEL_TYPE_MAP } from '@ui/constants/index';
+import { useAssetClaimableRewards } from '@ui/hooks/rewards/useAssetClaimableRewards';
+
+import { type FlywheelClaimableRewards } from '@ionicprotocol/sdk';
+
+interface UseFlywheelRewardsReturn {
+  filteredRewards: FlywheelClaimableRewards[];
+  totalRewards: bigint;
+  combinedRewards: FlywheelClaimableRewards[];
+  hasActiveRewards: boolean;
+}
+
+const processFlywheelRewards = (
+  rewardsData: FlywheelClaimableRewards[] | null | undefined,
+  chainId: number,
+  type: 'borrow' | 'supply'
+): UseFlywheelRewardsReturn => {
+  const filtered =
+    rewardsData?.filter((reward) =>
+      FLYWHEEL_TYPE_MAP[chainId][type]
+        .map((f) => f.toLowerCase())
+        .includes(reward.flywheel?.toLowerCase() ?? '')
+    ) ?? [];
+
+  const total = filtered.reduce((acc, reward) => acc + reward.amount, 0n);
+
+  const combined = filtered.reduce((acc, reward) => {
+    const el = acc.find((a) => a.rewardToken === reward.rewardToken);
+    if (el) {
+      el.amount += reward.amount;
+    } else {
+      acc.push({ rewardToken: reward.rewardToken, amount: reward.amount });
+    }
+    return acc;
+  }, [] as FlywheelClaimableRewards[]);
+
+  return {
+    filteredRewards: filtered,
+    totalRewards: total,
+    combinedRewards: combined,
+    hasActiveRewards: total > 0n || combined.length > 0
+  };
+};
+
+export function useFlywheelRewards(
+  chainId: number,
+  cToken: Address,
+  pool: Address,
+  type: 'borrow' | 'supply'
+): UseFlywheelRewardsReturn {
+  const { data: rewardsData } = useAssetClaimableRewards(cToken, pool, chainId);
+
+  return useMemo(
+    () => processFlywheelRewards(rewardsData, chainId, type),
+    [rewardsData, chainId, type]
+  );
+}

--- a/packages/ui/hooks/useRewardsBadge.ts
+++ b/packages/ui/hooks/useRewardsBadge.ts
@@ -1,0 +1,53 @@
+// useRewardsBadge.ts
+import { useMemo } from 'react';
+
+import { REWARDS_TO_SYMBOL } from '@ui/constants/index';
+import { multipliers } from '@ui/utils/multipliers';
+
+import type { FlywheelReward } from '@ionicprotocol/types';
+
+const EXCLUDED_REWARD_KEYS = [
+  'ionAPR',
+  'rewards',
+  'turtle',
+  'flywheel'
+] as const;
+
+const hasNonIonRewards = (
+  rewards: FlywheelReward[] | undefined,
+  chainId: number
+): boolean => {
+  return Boolean(
+    rewards?.some(
+      (r) =>
+        r?.apy && r.apy > 0 && REWARDS_TO_SYMBOL[chainId]?.[r?.token] !== 'ION'
+    )
+  );
+};
+
+const hasAdditionalRewards = (
+  config: Record<string, any> | undefined
+): boolean => {
+  if (!config) return false;
+
+  const truthyKeys = Object.entries(config)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    .filter(([_, value]) => Boolean(value))
+    .map(([key]) => key);
+
+  return truthyKeys.some((key) => !EXCLUDED_REWARD_KEYS.includes(key as any));
+};
+
+export function useRewardsBadge(
+  chainId: number,
+  poolId: string,
+  asset: string,
+  type: 'borrow' | 'supply',
+  rewards?: FlywheelReward[]
+): boolean {
+  return useMemo(() => {
+    const config = multipliers[chainId]?.[poolId]?.[asset]?.[type];
+
+    return hasNonIonRewards(rewards, chainId) || hasAdditionalRewards(config);
+  }, [chainId, poolId, asset, type, rewards]);
+}

--- a/packages/ui/hooks/useRewardsBadge.ts
+++ b/packages/ui/hooks/useRewardsBadge.ts
@@ -6,12 +6,7 @@ import { multipliers } from '@ui/utils/multipliers';
 
 import type { FlywheelReward } from '@ionicprotocol/types';
 
-const EXCLUDED_REWARD_KEYS = [
-  'ionAPR',
-  'rewards',
-  'turtle',
-  'flywheel'
-] as const;
+const EXCLUDED_REWARD_KEYS = ['ionAPR', 'turtle', 'flywheel'] as const;
 
 const hasNonIonRewards = (
   rewards: FlywheelReward[] | undefined,

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -18,6 +18,7 @@ export type Multipliers = {
   underlyingAPR?: number;
   nektar?: number;
   op?: boolean;
+  anzen?: number;
 };
 
 export const multipliers: Record<
@@ -643,7 +644,8 @@ export const multipliers: Record<
           turtle: false,
           rewards: true,
           ionAPR: true,
-          flywheel: true
+          flywheel: true,
+          anzen: 20
         }
       },
       EURC: {

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -8,12 +8,10 @@ export type Multipliers = {
   etherfi?: number;
   ionic: number;
   kelp?: number;
-  mode?: number;
   renzo?: number;
   flywheel?: boolean;
   ionAPR?: boolean;
   turtle?: boolean;
-  rewards?: boolean;
   spice?: boolean;
   underlyingAPR?: number;
   nektar?: number;
@@ -42,36 +40,28 @@ export const multipliers: Record<
       'M-BTC': {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         market: 'm_btc_market',
         multiplier: 66000,
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
       },
       dMBTC: {
         borrow: {
-          rewards: false,
           ionAPR: false,
           turtle: false,
-          ionic: 0,
-          mode: 0
+          ionic: 0
         },
         market: 'dmBTC_market',
         supply: {
           ionic: 0,
-          mode: 0,
           underlyingAPR: 10,
-          rewards: true,
           turtle: false,
           ionAPR: true,
           flywheel: true
@@ -80,9 +70,7 @@ export const multipliers: Record<
       STONE: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: true,
-          rewards: false,
           ionAPR: false
         },
         market: 'ststone_market',
@@ -90,18 +78,14 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           underlyingAPR: 2.94,
-          mode: 0,
           turtle: true,
-          rewards: true,
           ionAPR: false
         }
       },
       USDC: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           flywheel: false
         },
@@ -109,9 +93,7 @@ export const multipliers: Record<
         market: 'usdc_market',
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           op: true
         }
@@ -119,18 +101,14 @@ export const multipliers: Record<
       USDT: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         decimals: 6,
         market: 'usdt_market',
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -138,9 +116,7 @@ export const multipliers: Record<
       WBTC: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         decimals: 8,
@@ -148,9 +124,7 @@ export const multipliers: Record<
         multiplier: 66000,
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -158,9 +132,7 @@ export const multipliers: Record<
       WETH: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           flywheel: false
         },
@@ -168,9 +140,7 @@ export const multipliers: Record<
         multiplier: 3000,
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           op: true
         }
@@ -178,7 +148,6 @@ export const multipliers: Record<
       ezETH: {
         borrow: {
           turtle: true,
-          rewards: false,
           ionAPR: false,
           ionic: 0
         },
@@ -187,65 +156,51 @@ export const multipliers: Record<
         supply: {
           eigenlayer: true,
           ionic: 0,
-          mode: 0,
           renzo: 2,
           underlyingAPR: 3.25,
           turtle: true,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
       },
       sUSDe: {
         borrow: {
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           ionic: 0
         },
         multiplier: 0,
         supply: {
           ionic: 0,
-          mode: 0,
           underlyingAPR: 4.5,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
       USDe: {
         borrow: {
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           ionic: 0
         },
         multiplier: 0,
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         }
       },
       msDAI: {
         borrow: {
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           ionic: 0
         },
         multiplier: 0,
         supply: {
           ionic: 0,
-          mode: 0,
           underlyingAPR: 6,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
@@ -254,9 +209,7 @@ export const multipliers: Record<
           eigenlayer: true,
           etherfi: 1,
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false,
           flywheel: false
         },
@@ -266,10 +219,8 @@ export const multipliers: Record<
           eigenlayer: true,
           etherfi: 3,
           ionic: 0,
-          mode: 0,
           underlyingAPR: 2.99,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -279,9 +230,7 @@ export const multipliers: Record<
           eigenlayer: true,
           ionic: 0,
           kelp: 1,
-          mode: 0,
           turtle: true,
-          rewards: true,
           ionAPR: false
         },
         market: 'wrsteth_market',
@@ -290,10 +239,8 @@ export const multipliers: Record<
           eigenlayer: true,
           ionic: 0,
           kelp: 2,
-          mode: 0,
           underlyingAPR: 3.63,
           turtle: true,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -303,9 +250,7 @@ export const multipliers: Record<
       MODE: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         },
@@ -313,9 +258,7 @@ export const multipliers: Record<
         multiplier: 0.035,
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           flywheel: false
         }
@@ -323,18 +266,14 @@ export const multipliers: Record<
       USDC: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         decimals: 6,
         market: 'ionusdc_modenative',
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -342,9 +281,7 @@ export const multipliers: Record<
       USDT: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           flywheel: false
         },
@@ -352,9 +289,7 @@ export const multipliers: Record<
         market: 'ionusdt_modenative',
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -362,18 +297,14 @@ export const multipliers: Record<
       WETH: {
         borrow: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         market: 'ionweth_modenative',
         multiplier: 3000,
         supply: {
           ionic: 0,
-          mode: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -387,14 +318,12 @@ export const multipliers: Record<
           flywheel: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true
         },
         supply: {
           flywheel: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
@@ -403,7 +332,6 @@ export const multipliers: Record<
           flywheel: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true
         },
         supply: {
@@ -412,7 +340,6 @@ export const multipliers: Record<
           nektar: 1,
           underlyingAPR: 2.6,
           turtle: false,
-          rewards: true,
           ionAPR: true
         }
       },
@@ -422,14 +349,12 @@ export const multipliers: Record<
           ionic: 0,
           underlyingAPR: 3.5,
           turtle: false,
-          rewards: true,
           ionAPR: true
         },
         borrow: {
           flywheel: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true
         }
       },
@@ -437,7 +362,6 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         },
         market: 'ionaero_base',
@@ -445,7 +369,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -454,7 +377,6 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         },
@@ -462,7 +384,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         },
@@ -472,7 +393,6 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         },
@@ -481,7 +401,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -490,7 +409,6 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         },
         market: 'ioncbeth_base',
@@ -498,7 +416,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -512,24 +429,21 @@ export const multipliers: Record<
           renzo: 2,
           underlyingAPR: 3.25,
           turtle: true,
-          rewards: true,
           ionAPR: false
         },
         borrow: {
           turtle: false,
-          rewards: true,
           ionAPR: false,
           ionic: 0
         }
       },
       'weETH.mode': {
-        borrow: { turtle: false, rewards: true, ionAPR: false, ionic: 0 },
+        borrow: { turtle: false, ionAPR: false, ionic: 0 },
         supply: {
           ionic: 0,
           etherfi: 3,
           underlyingAPR: 2.99,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -537,7 +451,6 @@ export const multipliers: Record<
       RSR: {
         borrow: {
           turtle: false,
-          rewards: false,
           ionAPR: false,
           ionic: 0,
           flywheel: false
@@ -545,7 +458,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -554,7 +466,6 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         market: 'ionwsteth_base',
@@ -563,7 +474,6 @@ export const multipliers: Record<
           ionic: 0,
           underlyingAPR: 2.9,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -572,14 +482,12 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         supply: {
           ionic: 0,
           underlyingAPR: 15,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
@@ -587,7 +495,6 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         },
@@ -595,7 +502,6 @@ export const multipliers: Record<
           ionic: 0,
           underlyingAPR: 5,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -604,13 +510,11 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false,
           flywheel: false
         }
@@ -619,14 +523,12 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         supply: {
           ionic: 0,
           underlyingAPR: 10,
           turtle: false,
-          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -635,14 +537,12 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         },
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true,
           anzen: 20
@@ -652,7 +552,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -661,7 +560,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -670,7 +568,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -682,7 +579,6 @@ export const multipliers: Record<
       USDC: {
         borrow: {
           turtle: false,
-          rewards: true,
           ionAPR: false,
           spice: true,
           ionic: 0
@@ -691,14 +587,12 @@ export const multipliers: Record<
           spice: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
       USDT: {
         borrow: {
           turtle: false,
-          rewards: true,
           ionAPR: false,
           spice: true,
           ionic: 0
@@ -707,14 +601,12 @@ export const multipliers: Record<
           spice: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
       WETH: {
         borrow: {
           turtle: false,
-          rewards: true,
           ionAPR: false,
           spice: true,
           ionic: 0
@@ -723,14 +615,12 @@ export const multipliers: Record<
           spice: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
       WBTC: {
         borrow: {
           turtle: false,
-          rewards: true,
           ionAPR: false,
           spice: true,
           ionic: 0
@@ -739,14 +629,12 @@ export const multipliers: Record<
           spice: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
       tBTC: {
         borrow: {
           turtle: false,
-          rewards: true,
           ionAPR: false,
           spice: true,
           ionic: 0
@@ -755,14 +643,12 @@ export const multipliers: Record<
           spice: true,
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
       SOV: {
         borrow: {
           turtle: false,
-          rewards: true,
           ionAPR: false,
           spice: true,
           ionic: 0
@@ -770,7 +656,6 @@ export const multipliers: Record<
         supply: {
           spice: true,
           ionic: 0,
-          rewards: true,
           turtle: false,
           ionAPR: false
         }
@@ -783,7 +668,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -792,7 +676,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -801,14 +684,12 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         supply: {
           ionic: 0,
           underlyingAPR: 2.9,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       },
@@ -817,7 +698,6 @@ export const multipliers: Record<
           ionic: 0,
           underlyingAPR: 5,
           turtle: false,
-          rewards: true,
           ionAPR: false,
           flywheel: false
         }
@@ -826,7 +706,6 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           turtle: false,
-          rewards: true,
           ionAPR: true,
           flywheel: true
         }
@@ -839,14 +718,12 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           turtle: false,
-          rewards: false,
           ionAPR: false
         },
         supply: {
           ionic: 0,
           underlyingAPR: 3.46,
           turtle: false,
-          rewards: true,
           ionAPR: false
         }
       }

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -36,14 +36,13 @@ export const multipliers: Record<
   >
 > = {
   [mode.id]: {
-    // main market
     '0': {
       'M-BTC': {
         borrow: {
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         },
         market: 'm_btc_market',
@@ -52,14 +51,14 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: true,
           flywheel: true
         }
       },
       dMBTC: {
         borrow: {
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           turtle: false,
           ionic: 0,
@@ -81,7 +80,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         },
         market: 'ststone_market',
@@ -91,7 +90,7 @@ export const multipliers: Record<
           underlyingAPR: 2.94,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         }
       },
@@ -100,7 +99,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           flywheel: false
         },
@@ -110,7 +109,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         }
       },
@@ -119,7 +118,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         },
         decimals: 6,
@@ -138,7 +137,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         },
         decimals: 8,
@@ -158,7 +157,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           flywheel: false
         },
@@ -168,12 +167,17 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         }
       },
       ezETH: {
-        borrow: { turtle: false, rewards: true, ionAPR: false, ionic: 0 },
+        borrow: {
+          turtle: false,
+          rewards: false,
+          ionAPR: false,
+          ionic: 0
+        },
         market: 'ezeth_market',
         multiplier: 3000,
         supply: {
@@ -192,7 +196,7 @@ export const multipliers: Record<
         borrow: {
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           ionic: 0
         },
@@ -202,7 +206,7 @@ export const multipliers: Record<
           mode: 0,
           underlyingAPR: 4.5,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         }
       },
@@ -210,7 +214,7 @@ export const multipliers: Record<
         borrow: {
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           ionic: 0
         },
@@ -219,7 +223,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         }
       },
@@ -227,7 +231,7 @@ export const multipliers: Record<
         borrow: {
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           ionic: 0
         },
@@ -237,7 +241,7 @@ export const multipliers: Record<
           mode: 0,
           underlyingAPR: 6,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         }
       },
@@ -291,8 +295,7 @@ export const multipliers: Record<
         }
       }
     },
-    //native
-    '1': {
+    1: {
       MODE: {
         borrow: {
           ionic: 0,
@@ -308,7 +311,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           flywheel: false
         }
@@ -318,7 +321,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         },
         decimals: 6,
@@ -337,7 +340,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false,
           flywheel: false
         },
@@ -357,7 +360,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: false
         },
         market: 'ionweth_modenative',

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -41,8 +41,8 @@ export const multipliers: Record<
       'M-BTC': {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         },
@@ -50,8 +50,8 @@ export const multipliers: Record<
         multiplier: 66000,
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -61,17 +61,17 @@ export const multipliers: Record<
         borrow: {
           rewards: true,
           ionAPR: false,
-          turtle: true,
+          turtle: false,
           ionic: 0,
-          mode: 1
+          mode: 0
         },
         market: 'dmBTC_market',
         supply: {
           ionic: 0,
-          mode: 2,
+          mode: 0,
           underlyingAPR: 10,
           rewards: true,
-          turtle: true,
+          turtle: false,
           ionAPR: true,
           flywheel: true
         }
@@ -79,8 +79,8 @@ export const multipliers: Record<
       STONE: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         },
@@ -89,8 +89,8 @@ export const multipliers: Record<
         supply: {
           ionic: 0,
           underlyingAPR: 2.94,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         }
@@ -98,8 +98,8 @@ export const multipliers: Record<
       USDC: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           flywheel: false
@@ -108,8 +108,8 @@ export const multipliers: Record<
         market: 'usdc_market',
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         }
@@ -117,8 +117,8 @@ export const multipliers: Record<
       USDT: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         },
@@ -126,8 +126,8 @@ export const multipliers: Record<
         market: 'usdt_market',
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -136,8 +136,8 @@ export const multipliers: Record<
       WBTC: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         },
@@ -146,8 +146,8 @@ export const multipliers: Record<
         multiplier: 66000,
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -156,8 +156,8 @@ export const multipliers: Record<
       WETH: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           flywheel: false
@@ -166,8 +166,8 @@ export const multipliers: Record<
         multiplier: 3000,
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         }
@@ -179,10 +179,10 @@ export const multipliers: Record<
         supply: {
           eigenlayer: true,
           ionic: 0,
-          mode: 2,
+          mode: 0,
           renzo: 2,
           underlyingAPR: 3.25,
-          turtle: true,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -190,8 +190,8 @@ export const multipliers: Record<
       },
       sUSDe: {
         borrow: {
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           ionic: 0
@@ -199,17 +199,17 @@ export const multipliers: Record<
         multiplier: 0,
         supply: {
           ionic: 0,
-          mode: 2,
+          mode: 0,
           underlyingAPR: 4.5,
-          turtle: true,
+          turtle: false,
           rewards: true,
           ionAPR: false
         }
       },
       USDe: {
         borrow: {
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           ionic: 0
@@ -217,16 +217,16 @@ export const multipliers: Record<
         multiplier: 0,
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         }
       },
       msDAI: {
         borrow: {
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           ionic: 0
@@ -234,9 +234,9 @@ export const multipliers: Record<
         multiplier: 0,
         supply: {
           ionic: 0,
-          mode: 2,
+          mode: 0,
           underlyingAPR: 6,
-          turtle: true,
+          turtle: false,
           rewards: true,
           ionAPR: false
         }
@@ -246,8 +246,8 @@ export const multipliers: Record<
           eigenlayer: true,
           etherfi: 1,
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           flywheel: false
@@ -258,9 +258,9 @@ export const multipliers: Record<
           eigenlayer: true,
           etherfi: 3,
           ionic: 0,
-          mode: 2,
+          mode: 0,
           underlyingAPR: 2.99,
-          turtle: true,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -271,8 +271,8 @@ export const multipliers: Record<
           eigenlayer: true,
           ionic: 0,
           kelp: 1,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         },
@@ -282,21 +282,22 @@ export const multipliers: Record<
           eigenlayer: true,
           ionic: 0,
           kelp: 2,
-          mode: 2,
+          mode: 0,
           underlyingAPR: 3.63,
-          turtle: true,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
         }
       }
     },
+    //native
     '1': {
       MODE: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -305,8 +306,8 @@ export const multipliers: Record<
         multiplier: 0.035,
         supply: {
           ionic: 0,
-          mode: 3,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           flywheel: false
@@ -315,8 +316,8 @@ export const multipliers: Record<
       USDC: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         },
@@ -324,8 +325,8 @@ export const multipliers: Record<
         market: 'ionusdc_modenative',
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -334,8 +335,8 @@ export const multipliers: Record<
       USDT: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           flywheel: false
@@ -344,8 +345,8 @@ export const multipliers: Record<
         market: 'ionusdt_modenative',
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -354,8 +355,8 @@ export const multipliers: Record<
       WETH: {
         borrow: {
           ionic: 0,
-          mode: 1,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: false
         },
@@ -363,8 +364,8 @@ export const multipliers: Record<
         multiplier: 3000,
         supply: {
           ionic: 0,
-          mode: 2,
-          turtle: true,
+          mode: 0,
+          turtle: false,
           rewards: true,
           ionAPR: true,
           flywheel: true

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -81,7 +81,7 @@ export const multipliers: Record<
         borrow: {
           ionic: 0,
           mode: 0,
-          turtle: false,
+          turtle: true,
           rewards: false,
           ionAPR: false
         },
@@ -91,7 +91,7 @@ export const multipliers: Record<
           ionic: 0,
           underlyingAPR: 2.94,
           mode: 0,
-          turtle: false,
+          turtle: true,
           rewards: true,
           ionAPR: false
         }
@@ -177,7 +177,7 @@ export const multipliers: Record<
       },
       ezETH: {
         borrow: {
-          turtle: false,
+          turtle: true,
           rewards: false,
           ionAPR: false,
           ionic: 0
@@ -190,7 +190,7 @@ export const multipliers: Record<
           mode: 0,
           renzo: 2,
           underlyingAPR: 3.25,
-          turtle: false,
+          turtle: true,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -280,7 +280,7 @@ export const multipliers: Record<
           ionic: 0,
           kelp: 1,
           mode: 0,
-          turtle: false,
+          turtle: true,
           rewards: true,
           ionAPR: false
         },
@@ -292,7 +292,7 @@ export const multipliers: Record<
           kelp: 2,
           mode: 0,
           underlyingAPR: 3.63,
-          turtle: false,
+          turtle: true,
           rewards: true,
           ionAPR: true,
           flywheel: true
@@ -511,12 +511,12 @@ export const multipliers: Record<
           ionic: 0,
           renzo: 2,
           underlyingAPR: 3.25,
-          turtle: false,
+          turtle: true,
           rewards: true,
           ionAPR: false
         },
         borrow: {
-          turtle: false,
+          turtle: true,
           rewards: true,
           ionAPR: false,
           ionic: 0

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -17,6 +17,7 @@ export type Multipliers = {
   spice?: boolean;
   underlyingAPR?: number;
   nektar?: number;
+  op?: boolean;
 };
 
 export const multipliers: Record<
@@ -110,7 +111,8 @@ export const multipliers: Record<
           mode: 0,
           turtle: false,
           rewards: false,
-          ionAPR: false
+          ionAPR: false,
+          op: true
         }
       },
       USDT: {
@@ -168,7 +170,8 @@ export const multipliers: Record<
           mode: 0,
           turtle: false,
           rewards: false,
-          ionAPR: false
+          ionAPR: false,
+          op: true
         }
       },
       ezETH: {
@@ -881,4 +884,20 @@ export const steerLPMultipliers: Record<string, LpMultipliers> = {
     priceMultiplier: 10,
     decimals: 6
   }
+};
+
+export const hasAdditionalRewards = (
+  chainId: number,
+  poolId: string,
+  asset: string,
+  type: 'borrow' | 'supply'
+): boolean => {
+  const supplyConfig = multipliers[chainId]?.[poolId]?.[asset]?.[type];
+  if (!supplyConfig) return false;
+
+  const excludedKeys = ['ionAPR', 'rewards', 'turtle', 'flywheel'];
+
+  return Object.entries(supplyConfig).some(
+    ([key, value]) => !excludedKeys.includes(key) && Boolean(value)
+  );
 };

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -127,7 +127,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -147,7 +147,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -301,7 +301,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: true,
           flywheel: true
         },
@@ -330,7 +330,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -350,7 +350,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: true,
           flywheel: true
         }
@@ -369,7 +369,7 @@ export const multipliers: Record<
           ionic: 0,
           mode: 0,
           turtle: false,
-          rewards: true,
+          rewards: false,
           ionAPR: true,
           flywheel: true
         }

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -516,7 +516,7 @@ export const multipliers: Record<
           ionAPR: false
         },
         borrow: {
-          turtle: true,
+          turtle: false,
           rewards: true,
           ionAPR: false,
           ionic: 0

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -147,7 +147,7 @@ export const multipliers: Record<
       },
       ezETH: {
         borrow: {
-          turtle: true,
+          turtle: false,
           ionAPR: false,
           ionic: 0
         },

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -885,19 +885,3 @@ export const steerLPMultipliers: Record<string, LpMultipliers> = {
     decimals: 6
   }
 };
-
-export const hasAdditionalRewards = (
-  chainId: number,
-  poolId: string,
-  asset: string,
-  type: 'borrow' | 'supply'
-): boolean => {
-  const supplyConfig = multipliers[chainId]?.[poolId]?.[asset]?.[type];
-  if (!supplyConfig) return false;
-
-  const excludedKeys = ['ionAPR', 'rewards', 'turtle', 'flywheel'];
-
-  return Object.entries(supplyConfig).some(
-    ([key, value]) => !excludedKeys.includes(key) && Boolean(value)
-  );
-};

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -90,7 +90,7 @@ export const multipliers: Record<
           underlyingAPR: 2.94,
           mode: 0,
           turtle: false,
-          rewards: false,
+          rewards: true,
           ionAPR: false
         }
       },
@@ -206,7 +206,7 @@ export const multipliers: Record<
           mode: 0,
           underlyingAPR: 4.5,
           turtle: false,
-          rewards: false,
+          rewards: true,
           ionAPR: false
         }
       },
@@ -241,7 +241,7 @@ export const multipliers: Record<
           mode: 0,
           underlyingAPR: 6,
           turtle: false,
-          rewards: false,
+          rewards: true,
           ionAPR: false
         }
       },


### PR DESCRIPTION
- killed all the “Mode Points” and “Mode Turtle Points” from Mode main and native markets
- removed OP rewards from mode native pool
- add turtle rewards to stone, wrseth and ezeth