### PR TITLE
Hide op rewards & show ion/native yield for dmbtc

### DIFF
--- a/packages/ui/app/_components/markets/SupplyPopover.tsx
+++ b/packages/ui/app/_components/markets/SupplyPopover.tsx
@@ -119,7 +119,7 @@ export default function SupplyPopover({
             %
           </span>
         </div>
-        {(merklAprForToken || asset === 'dMBTC') && (
+        {merklAprForToken && (
           <div className="flex items-center mt-1">
             <img
               src="/images/op-logo-red.svg"

--- a/packages/ui/utils/multipliers.ts
+++ b/packages/ui/utils/multipliers.ts
@@ -50,6 +50,21 @@ export const multipliers: Record<
           op: true
         }
       },
+      dMBTC: {
+        borrow: {
+          ionAPR: false,
+          turtle: false,
+          ionic: 0
+        },
+        market: 'dmBTC_market',
+        supply: {
+          ionic: 0,
+          underlyingAPR: 10,
+          turtle: false,
+          ionAPR: true,
+          flywheel: true
+        }
+      },
       STONE: {
         borrow: {
           ionic: 0,


### PR DESCRIPTION
![Screenshot 2024-11-29 at 11 56 18](https://github.com/user-attachments/assets/1d7ef4f9-188d-47fd-87d5-9836ecfbbfa8)
