### PR TITLE
Add veapr

### DIFF
--- a/packages/ui/components/veion/VotesManagement.tsx
+++ b/packages/ui/components/veion/VotesManagement.tsx
@@ -239,12 +239,39 @@ function VotesManagement({
       id: 'veAPR',
       accessorFn: (row) => row.veAPR,
       header: (
-        <TooltipWrapper content="Current voting APR">
+        <TooltipWrapper content="Annual Percentage Yield from voting incentives (bribes)">
           <span>veAPR</span>
         </TooltipWrapper>
       ),
       sortingFn: 'numerical',
-      cell: ({ row }) => <span>{row.original.veAPR.toFixed(2)}</span>
+      cell: ({ row }) => {
+        const veAPR = row.original.veAPR;
+
+        let colorClass = 'text-white/80';
+        if (veAPR > 1000000) colorClass = 'text-green-500 font-bold';
+        else if (veAPR > 10000) colorClass = 'text-green-400';
+        else if (veAPR > 1000) colorClass = 'text-green-300';
+        else if (veAPR > 100) colorClass = 'text-green-200';
+
+        let displayValue = '-';
+        if (veAPR > 0) {
+          if (veAPR > 1e20) {
+            displayValue = '∞%';
+          } else if (veAPR > 1e12) {
+            displayValue = `${(veAPR / 1e12).toFixed(2)}T%`;
+          } else if (veAPR > 1e9) {
+            displayValue = `${(veAPR / 1e9).toFixed(2)}B%`;
+          } else if (veAPR > 1e6) {
+            displayValue = `${(veAPR / 1e6).toFixed(2)}M%`;
+          } else if (veAPR > 1e3) {
+            displayValue = `${(veAPR / 1e3).toFixed(2)}K%`;
+          } else {
+            displayValue = `${veAPR.toFixed(2)}%`;
+          }
+        }
+
+        return <span className={colorClass}>{displayValue}</span>;
+      }
     },
     {
       id: 'totalVotes.limit',

--- a/packages/ui/hooks/veion/useMarketRows.ts
+++ b/packages/ui/hooks/veion/useMarketRows.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
 
 import { EXCLUDED_MARKETS } from '@ui/constants/veIon';
+import { useVeIONContext } from '@ui/context/VeIonContext'; // Add this import
 import { useBorrowAPYs } from '@ui/hooks/useBorrowAPYs';
 import { useFusePoolData } from '@ui/hooks/useFusePoolData';
 import { useMerklData } from '@ui/hooks/useMerklData';
@@ -10,6 +11,7 @@ import { useMarketIncentives } from '@ui/hooks/veion/useMarketIncentives';
 import type { VoteMarketRow } from '@ui/types/veION';
 import { MarketSide } from '@ui/types/veION';
 import { calculateTotalAPR } from '@ui/utils/marketUtils';
+import { calculateVeAPR } from '@ui/utils/veion/veAPRUtils';
 
 import { useVoteData } from './useVoteData';
 
@@ -20,6 +22,21 @@ export const useMarketRows = (
 ) => {
   const [baseMarketRows, setBaseMarketRows] = useState<VoteMarketRow[]>([]);
   const [error, setError] = useState<Error | null>(null);
+
+  const {
+    prices: { veIonBalanceUsd },
+    locks
+  } = useVeIONContext();
+
+  const veIonPrice = useMemo(() => {
+    const totalVotingPower = locks.myLocks.reduce(
+      (acc, lock) => acc + Number(lock.votingPower),
+      0
+    );
+    if (totalVotingPower <= 0) return 0;
+
+    return veIonBalanceUsd / totalVotingPower;
+  }, [veIonBalanceUsd, locks.myLocks]);
 
   const { data: poolData, isLoading: isLoadingPoolData } = useFusePoolData(
     selectedPool,
@@ -66,7 +83,7 @@ export const useMarketRows = (
     return { marketAddresses: addresses, marketSides: sides, lpTokens: tokens };
   }, [chain, poolData?.assets]);
 
-  // Use the new market incentives hook for fetching incentives
+  // Use the market incentives hook for fetching incentives
   const {
     incentivesData,
     marketTokensDetails,
@@ -122,6 +139,29 @@ export const useMarketRows = (
     [incentivesData, marketTokensDetails]
   );
 
+  const calculateMarketVeAPR = useCallback(
+    (
+      marketAddress: string,
+      side: MarketSide,
+      totalVotes: { percentage: number; limit: number }
+    ) => {
+      const normalizedAddress = marketAddress.toLowerCase();
+
+      // Get incentive USD value
+      const incentiveUsdValue =
+        side === MarketSide.Supply
+          ? incentivesData[normalizedAddress]?.supplyUsd || 0
+          : incentivesData[normalizedAddress]?.borrowUsd || 0;
+
+      // Calculate total votes value in USD using the veION price
+      const totalVotesValueUSD = totalVotes.limit * veIonPrice;
+
+      // Calculate veAPR (using weekly period for bribes)
+      return calculateVeAPR(incentiveUsdValue, totalVotesValueUSD, true);
+    },
+    [incentivesData, veIonPrice]
+  );
+
   const processMarketRows = useCallback(() => {
     if (!poolData?.assets || poolData.assets.length === 0) return [];
 
@@ -130,6 +170,20 @@ export const useMarketRows = (
 
       if (!EXCLUDED_MARKETS[+chain]?.[asset.underlyingSymbol]?.supply) {
         const key = `${asset.cToken}-supply`;
+        const totalVotes = voteData[key]?.totalVotes ?? {
+          percentage: 0,
+          limit: 0
+        };
+        const incentives = getIncentivesFromBribes(
+          asset.cToken,
+          MarketSide.Supply
+        );
+
+        const veAPR = calculateMarketVeAPR(
+          asset.cToken,
+          MarketSide.Supply,
+          totalVotes
+        );
 
         newRows.push({
           asset: asset.underlyingSymbol,
@@ -137,12 +191,9 @@ export const useMarketRows = (
           side: MarketSide.Supply,
           marketAddress: asset.cToken as `0x${string}`,
           currentAmount: asset.totalSupplyFiat.toFixed(2),
-          incentives: getIncentivesFromBribes(asset.cToken, MarketSide.Supply),
-          veAPR: 0,
-          totalVotes: voteData[key]?.totalVotes ?? {
-            percentage: 0,
-            limit: 0
-          },
+          incentives,
+          veAPR,
+          totalVotes,
           myVotes: voteData[key]?.myVotes ?? {
             percentage: 0,
             value: 0
@@ -166,6 +217,20 @@ export const useMarketRows = (
 
       if (!EXCLUDED_MARKETS[+chain]?.[asset.underlyingSymbol]?.borrow) {
         const key = `${asset.cToken}-borrow`;
+        const totalVotes = voteData[key]?.totalVotes ?? {
+          percentage: 0,
+          limit: 0
+        };
+        const incentives = getIncentivesFromBribes(
+          asset.cToken,
+          MarketSide.Borrow
+        );
+
+        const veAPR = calculateMarketVeAPR(
+          asset.cToken,
+          MarketSide.Borrow,
+          totalVotes
+        );
 
         newRows.push({
           asset: asset.underlyingSymbol,
@@ -173,12 +238,9 @@ export const useMarketRows = (
           side: MarketSide.Borrow,
           marketAddress: asset.cToken as `0x${string}`,
           currentAmount: asset.totalBorrowFiat.toFixed(2),
-          incentives: getIncentivesFromBribes(asset.cToken, MarketSide.Borrow),
-          veAPR: 0,
-          totalVotes: voteData[key]?.totalVotes ?? {
-            percentage: 0,
-            limit: 0
-          },
+          incentives,
+          veAPR,
+          totalVotes,
           myVotes: voteData[key]?.myVotes ?? {
             percentage: 0,
             value: 0
@@ -211,6 +273,10 @@ export const useMarketRows = (
     rewards,
     merklApr,
     voteData
+    // getIncentivesFromBribes,
+    // calculateMarketVeAPR,
+    // poolData?.assets,
+    // poolData?.comptroller
   ]);
 
   useEffect(() => {

--- a/packages/ui/utils/veion/veAPRUtils.ts
+++ b/packages/ui/utils/veion/veAPRUtils.ts
@@ -1,0 +1,31 @@
+// Function to calculate the veAPR (Bribe ROI as APY)
+export const calculateVeAPR = (
+  incentiveUsdValue: number, // Weekly incentive value in USD
+  totalVotesValue: number, // Total value of veION votes for this market
+  weeklyPeriod: boolean = true // Whether the incentive period is weekly (true) or not
+): number => {
+  if (totalVotesValue <= 0 || incentiveUsdValue <= 0) {
+    return 0;
+  }
+
+  // Calculate weekly ROI
+  const weeklyROI = incentiveUsdValue / totalVotesValue;
+
+  // Annualize based on weekly compounding (52 weeks)
+  // If the period is not weekly, adjust accordingly
+  const periodsPerYear = weeklyPeriod ? 52 : 365; // Default to daily if not weekly
+
+  // Calculate APY with compounding using the formula: (1 + r)^n - 1
+  const annualizedAPR = Math.pow(1 + weeklyROI, periodsPerYear) - 1;
+
+  // Convert to percentage and return
+  return annualizedAPR * 100;
+};
+
+// Helper function to estimate total votes value in USD
+export const estimateTotalVotesValueUSD = (
+  totalVotes: { percentage: number; limit: number },
+  veIonPrice: number // Price of veION in USD
+): number => {
+  return totalVotes.limit * veIonPrice;
+};


### PR DESCRIPTION
- calculate weekly roi as: incentive usd value / total votes value
- annualize using compound interest formula: (1 + weekly roi)^52 - 1
- convert to percentage by multiplying by 100
- display with K/M/B/T suffixes for large values
- extremely large values (>10^20%) display as infinity
- uses same approach as aerodrome's bribe roi calculation
- high veAPR signals profitable voting opportunities