### PR TITLE
Refactor Network and Navbar Components to Remove Testnet References

### DIFF
--- a/packages/ui/app/market/page.tsx
+++ b/packages/ui/app/market/page.tsx
@@ -139,7 +139,7 @@ export default function Market() {
         <div className="w-full my-4 flex flex-wrap">
           <NetworkSelector
             dropdownSelectedChain={+chain}
-            upcomingChains={['FX', 'Kroma', 'Unichain']}
+            // upcomingChains={['FX', 'Kroma', 'Unichain']}
           />
         </div>
         <div className="bg-grayone w-full rounded-xl py-4 px-4 lg:px-[1%] xl:px-[3%]">

--- a/packages/ui/components/Navbar.tsx
+++ b/packages/ui/components/Navbar.tsx
@@ -150,11 +150,11 @@ export default function Navbar() {
             label="Earn"
             isActive={pathname === '/earn'}
           />
-          <NavLink
+          {/* <NavLink
             href="/claim"
             label="Claim"
             isActive={pathname === '/claim'}
-          />
+          /> */}
           <NavLink
             href="/incentives"
             label="Incentivize"

--- a/packages/ui/components/markets/NetworkSelector.tsx
+++ b/packages/ui/components/markets/NetworkSelector.tsx
@@ -39,9 +39,9 @@ const ACTIVE_NETWORKS = [
   'Worldchain',
   'Swell',
   'Soneium',
-  'Superseed',
-  'Ozean Testnet',
-  'Camp Testnet'
+  'Superseed'
+  // 'Ozean Testnet',
+  // 'Camp Testnet'
 ];
 
 export const ALL_CHAINS_VALUE = 0;

--- a/packages/ui/config/web3.ts
+++ b/packages/ui/config/web3.ts
@@ -74,40 +74,6 @@ export const swellchain: AppKitNetwork = {
   }
 };
 
-export const camptest: AppKitNetwork = {
-  id: 325000,
-  name: 'Camp Testnet',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-  rpcUrls: {
-    default: {
-      http: ['https://rpc-campnetwork.xyz']
-    }
-  },
-  blockExplorers: {
-    default: {
-      name: 'Camp Testnet Explorer',
-      url: 'https://camp-network-testnet.blockscout.com',
-      apiUrl: 'https://camp-network-testnet.blockscout.com/api'
-    }
-  }
-};
-
-export const ozeantest: AppKitNetwork = {
-  id: 7849306,
-  name: 'Ozean Testnet',
-  nativeCurrency: { name: 'USDX', symbol: 'USDX', decimals: 18 },
-  rpcUrls: {
-    default: { http: ['https://ozean-testnet.rpc.caldera.xyz/http'] }
-  },
-  blockExplorers: {
-    default: {
-      name: 'Ozean Testnet Explorer',
-      url: 'https://ozean-testnet.explorer.caldera.xyz',
-      apiUrl: 'https://ozean-testnet.explorer.caldera.xyz/api'
-    }
-  }
-};
-
 export const soneium: AppKitNetwork = {
   id: 1868,
   name: 'Soneium',
@@ -140,9 +106,7 @@ export const networks: AppKitNetwork[] = [
   superseed,
   worldchain,
   fraxtal,
-  swellchain,
-  camptest,
-  ozeantest
+  swellchain
 ];
 
 export const metadata = {

--- a/packages/ui/constants/index.ts
+++ b/packages/ui/constants/index.ts
@@ -14,13 +14,7 @@ import type { TxStep } from '@ui/types/ComponentPropsType';
 
 import type { Address } from 'viem';
 
-import {
-  camptest,
-  ink,
-  ozeantest,
-  soneium,
-  swellchain
-} from '@ionicprotocol/chains';
+import { ink, soneium, swellchain } from '@ionicprotocol/chains';
 import { SupportedChainsArray } from '@ionicprotocol/types';
 
 export const SUPPORTED_NETWORKS_REGEX = new RegExp(
@@ -418,32 +412,6 @@ export const pools: Record<number, PoolParams> = {
         id: '0',
         name: 'Main Pool',
         assets: ['WETH', 'USDe', 'rswETH', 'weETH']
-      }
-    ]
-  },
-  [camptest.chainId]: {
-    name: 'Camp Testnet',
-    arrow: 'ffffff',
-    bg: 'bg-camp',
-    text: 'text-white',
-    border: 'border-camp',
-    logo: '/img/logo/CAMP.png',
-    pools: [{ id: '0', name: 'Main Pool', assets: ['WETH'] }]
-  },
-  [ozeantest.chainId]: {
-    arrow: 'ffffff',
-    name: 'Ozean Testnet',
-    hexcode: '#2467ed',
-    bg: 'bg-blue-600',
-    accentbg: 'bg-blue-600',
-    text: 'text-white',
-    border: 'border-base',
-    logo: '/img/logo/OZEAN.png',
-    pools: [
-      {
-        id: '0',
-        name: 'Main Pool',
-        assets: ['WUSDX']
       }
     ]
   },


### PR DESCRIPTION
- Commented out upcoming chains in NetworkSelector and removed references to 'Camp Testnet' and 'Ozean Testnet' from Navbar and web3 configuration.
- Updated constants to reflect the removal of testnet networks, streamlining the codebase.

## Description

<!--- Provide a general summary of your changes in the Title above -->

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

<!--- Describe your changes in more detail -->

## Related Issue(s)

Fixes <!--- Please link to the issue here: -->

## Related pull request(s)

<!--- Please link to the PRs here: -->

<!--- adapted from https://github.com/inversify/inversify-basic-example/blob/master/PULL_REQUEST_TEMPLATE.md -->
